### PR TITLE
Switch to CoC, Nord Theme, FZF

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,7 +3,11 @@
   excludesfile = ~/.gitignore_global
   editor = vim
   # pager = less -F -X
-  pager = delta --dark --theme='Solarized (dark)'
+  pager = delta
+
+[delta]
+  syntax-theme = Nord
+  navigate = true
 
 # These are custom color options for the console
 [color]

--- a/.gitconfig
+++ b/.gitconfig
@@ -60,6 +60,9 @@
   current-branch = rev-parse --abbrev-ref HEAD
   cb = !git current-branch
 
+  wip = !git -m WIP
+  awip = !git amend -m WIP
+
   push-this = "!. ~/.githelpers && push_this"
 [user]
   name = Liam McCartney

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,18 +1,64 @@
 set-option -g default-shell $SHELL
 unbind C-b
 set -g prefix C-s
+
+set -g default-terminal "xterm-256color"
+
 set -g mouse on
-bind-key - split-window -v -c '#{pane_current_path}'
-bind-key / split-window -h -c '#{pane_current_path}'
+
+set -g history-limit 102400
+
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Use emacs keybindings in the status line
+set-option -g status-keys emacs
+
+# Use vim keybindings in copy mode
 setw -g mode-keys vi
+
+# Fix ESC delay in vim
+set -g escape-time 10
+
+bind C-s send-prefix
+
+unbind-key -T copy-mode-vi v
+
+bind-key -T copy-mode-vi v \
+  send-keys -X begin-selection
+
+bind-key -T copy-mode-vi 'C-v' \
+  send-keys -X rectangle-toggle
+
+bind-key -T copy-mode-vi y \
+  send-keys -X copy-pipe-and-cancel "pbcopy"
+
+bind-key -T copy-mode-vi MouseDragEnd1Pane \
+  send-keys -X copy-pipe-and-cancel "pbcopy"
+
+bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+
+bind c new-window -c '#{pane_current_path}'
+bind '\' split-window -h -c '#{pane_current_path}'
+bind - split-window -v -c '#{pane_current_path}'
+
+bind b break-pane -d
+
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-set -g window-status-format '#I:#(pwd="#{pane_current_path}"; echo ${pwd####*/})#F'
-set -g window-status-current-format '#I:#(pwd="#{pane_current_path}"; echo ${pwd####*/})#F'
-set-option -g status-interval 1
+set-option -g status-justify left
+set-option -g status-left '#[bg=colour72] #[bg=colour237] #[bg=colour236] #[bg=colour235]#[fg=colour185] #S #[bg=colour236] '
+set-option -g status-left-length 16
+set-option -g status-bg colour237
+set-option -g status-right '#[bg=colour236] #[bg=colour235]#[fg=colour185] %a %R #[bg=colour236]#[fg=colour3] #[bg=colour237] #[bg=colour72] #[]'
+set-option -g status-interval 60
 
-set -g default-terminal "tmux-256color"
-set -ga terminal-overrides ",*256col*:Tc"
+set-option -g pane-active-border-style fg=colour246
+set-option -g pane-border-style fg=colour238
+
+set-window-option -g window-status-format '#[bg=colour238]#[fg=colour107] #I #[bg=colour239]#[fg=colour110] #[bg=colour240]#W#[bg=colour239]#[fg=colour195]#F#[bg=colour238] '
+set-window-option -g window-status-current-format '#[bg=colour236]#[fg=colour215] #I #[bg=colour235]#[fg=colour167] #[bg=colour234]#W#[bg=colour235]#[fg=colour195]#F#[bg=colour236] '

--- a/.vimrc
+++ b/.vimrc
@@ -32,7 +32,8 @@ call plug#begin('~/.vim/plugged')
   Plug 'dense-analysis/ale'
 
   " file finder, buffer manager
-  Plug 'ctrlpvim/ctrlp.vim'
+  Plug '/usr/local/opt/fzf'
+  Plug 'junegunn/fzf.vim'
 
   " Extends % to match many more kinds of surrounding symbols
   Plug 'tmhedberg/matchit'
@@ -456,15 +457,10 @@ endfunction
 command! OpenChangedFiles :call OpenChangedFiles()
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" CtrlP Config
+" FZF Config
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-let g:ctrlp_map = '<c-f>'
-let g:ctrlp_working_path_mode = 0
-let g:ctrlp_custom_ignore = {
-      \ 'dir':  '\v[\/]\.(git|hg|svn)|node_modules|vendor|elm-stuff|plugins|tmp|_build|deps|katielovell\/public|FulcrumProduct\/wwwroot\/codecoverage|netcoreapp3.1|net5.0$',
-      \ 'file': '\v\.(exe|so|dll|DS_Store|beam)$',
-      \ 'link': '',
-      \ }
+nmap <c-f> :FZF<CR>
+nmap <c-b> :Buffers<CR>
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " CleanExtraSpaces

--- a/.vimrc
+++ b/.vimrc
@@ -59,15 +59,13 @@ call plug#begin('~/.vim/plugged')
   Plug 'jlcrochet/vim-razor'
 
   " Language specifc semantics
-  Plug 'Quramy/tsuquyomi'
+  " Plug 'Quramy/tsuquyomi'
   Plug 'OmniSharp/omnisharp-vim'
   Plug 'nickspoons/vim-sharpenup'
-  Plug 'dart-lang/dart-vim-plugin'
+  " Plug 'dart-lang/dart-vim-plugin'
 
   " Autocomplete
-  Plug 'Shougo/deoplete.nvim'
-  Plug 'roxma/nvim-yarp'
-  Plug 'roxma/vim-hug-neovim-rpc'
+  Plug 'neoclide/coc.nvim', {'branch': 'release'}
 call plug#end()
 
 """""""""""""""""""""""""""""
@@ -317,6 +315,7 @@ let g:ale_lint_delay = 0
 let g:ale_set_quickfix = 0
 let g:ale_set_loclist = 0
 let g:ale_fix_on_save = 1
+let g:ale_disable_lsp = 1
 
 highlight ALEWarning cterm=underline,bold,italic ctermfg=Yellow
 highlight ALEError cterm=underline,bold,italic ctermfg=Red
@@ -359,8 +358,8 @@ let g:ale_elixir_elixir_ls_release = "/Users/liam/LanguageServers/elixir-ls/"
 let g:ale_dart_dartanalyzer_executable = "dart analyze"
 let g:ale_dart_dartfmt_executable = "dart format"
 
-nnoremap <leader>a <Plug>(ale_next_wrap_error)
-nnoremap <leader>A <Plug>(ale_previous_wrap_error)
+nmap <silent> <leader>a <Plug>(ale_next_wrap_error)
+nmap <silent> <leader>a <Plug>(ale_previous_wrap_error)
 nnoremap <leader>kA :ALEStopAllLSPs<cr>
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -656,6 +655,11 @@ let g:OmniSharp_highlight_groups = {
 "" Tsuquyomi
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "" Vim-ale handles TypeScript quickfix, so tell Tsuquyomi not to do it.
-let g:tsuquyomi_disable_quickfix = 1
-nnoremap <leader>tf :TsuQuickFix<cr>
-let g:tsuquyomi_shortest_import_path = 1
+" let g:tsuquyomi_disable_quickfix = 1
+" nnoremap <leader>tf :TsuQuickFix<cr>
+" let g:tsuquyomi_shortest_import_path = 1
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+"" Coc
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+nmap <leader>qf  <Plug>(coc-fix-current)

--- a/.vimrc
+++ b/.vimrc
@@ -12,7 +12,9 @@ endif
 
 call plug#begin('~/.vim/plugged')
   " Theme
-  Plug 'haishanh/night-owl.vim'
+  Plug 'ghifarit53/tokyonight-vim'
+  Plug 'sheerun/vim-polyglot'
+  Plug 'ryanoasis/vim-devicons'
 
   " Status Bar
   Plug 'itchyny/lightline.vim'
@@ -50,11 +52,11 @@ call plug#begin('~/.vim/plugged')
   Plug 'mileszs/ack.vim'
   
   " Syntax
-  Plug 'elixir-editors/vim-elixir'
-  Plug 'cespare/vim-toml'
-  Plug 'ElmCast/elm-vim'
-  Plug 'leafgarland/typescript-vim'
-  Plug 'jlcrochet/vim-razor'
+  " Plug 'elixir-editors/vim-elixir'
+  " Plug 'cespare/vim-toml'
+  " Plug 'ElmCast/elm-vim'
+  " Plug 'leafgarland/typescript-vim'
+  " Plug 'jlcrochet/vim-razor'
 
   " Language specifc semantics
   " Plug 'Quramy/tsuquyomi'
@@ -159,16 +161,6 @@ set nojoinspaces
 " If a file is changed outside of vim, automatically reload it without asking
 set autoread
 
-"""""""""""""""""""""""""""
-" I have turnd this off, because I don't know if it's necessary anymore
-" I suspect it might have been the culprit for my broken jsx & typescript
-" syntax highlighting, but I have no proof as of March 30 2020
-"""""""""""""""""""""""""""
-" Use the old vim regex engine (version 1, as opposed to version 2, which was
-" introduced in Vim 7.3.969). The Ruby syntax highlighting is significantly
-" slower with the new regex engine.
-" set re=1
-
 " Stop SQL language files from doing unholy things to the C-c key
 let g:omni_sql_no_default_maps = 1
 
@@ -227,29 +219,22 @@ augroup END
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Color
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" set t_Co=256 " 256 colors
-set background=dark
-colorscheme night-owl
-let g:one_allow_italics=1
+set termguicolors
+let g:tokyonight_style = 'night' " available: night, storm
+let g:tokyonight_enable_italic = 1
+let g:tokyonight_transparent_background = 1
+colorscheme tokyonight
 
 " Highlight current line.
 set cursorline
 hi clear CursorLine
 hi CursorLine cterm=underline gui=underline
 
-" True Colors for tmux
-" https://github.com/tmux/tmux/issues/1246
-if (has("termguicolors"))
-  let &t_8f="\<Esc>[38;2;%lu;%lu;%lum"
-  let &t_8b="\<Esc>[48;2;%lu;%lu;%lum"
-  set termguicolors
-endif
-
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Lightline Config
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:lightline = {
-      \ 'colorscheme': 'nightowl',
+      \ 'colorscheme': 'tokyonight',
       \ 'active': {
       \   'right': [
       \     ['lineinfo'], ['percent'],
@@ -593,7 +578,7 @@ let g:ale_sign_info = '❗️'
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "" Coc
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-set encoding=utf-8
+set encoding=UTF-8
 set updatetime=300
 set cmdheight=2
 set shortmess+=c

--- a/.vimrc
+++ b/.vimrc
@@ -646,3 +646,32 @@ nnoremap <silent><nowait> <space>a  :<C-u>CocList diagnostics<cr>
 command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
 
 let $NVIM_TUI_ENABLE_TRUE_COLOR=1
+
+
+function! TextEnableCodeSnip(filetype,start,end,textSnipHl) abort
+  let ft=toupper(a:filetype)
+  let group='textGroup'.ft
+  if exists('b:current_syntax')
+    let s:current_syntax=b:current_syntax
+    " Remove current syntax definition, as some syntax files (e.g. cpp.vim)
+    " do nothing if b:current_syntax is defined.
+    unlet b:current_syntax
+  endif
+  execute 'syntax include @'.group.' syntax/'.a:filetype.'.vim'
+  try
+    execute 'syntax include @'.group.' after/syntax/'.a:filetype.'.vim'
+  catch
+  endtry
+  if exists('s:current_syntax')
+    let b:current_syntax=s:current_syntax
+  else
+    unlet b:current_syntax
+  endif
+  execute 'syntax region textSnip'.ft.'
+  \ matchgroup='.a:textSnipHl.'
+  \ keepend
+  \ start="'.a:start.'" end="'.a:end.'"
+  \ contains=@'.group
+endfunction
+
+autocmd BufNewFile,BufRead *.razor call TextEnableCodeSnip('cs', '@code {', '\n}', 'SpecialComment')

--- a/.vimrc
+++ b/.vimrc
@@ -12,7 +12,7 @@ endif
 
 call plug#begin('~/.vim/plugged')
   " Theme
-  Plug 'ghifarit53/tokyonight-vim'
+  Plug 'arcticicestudio/nord-vim'
   Plug 'sheerun/vim-polyglot'
   Plug 'ryanoasis/vim-devicons'
 
@@ -220,10 +220,7 @@ augroup END
 " Color
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 set termguicolors
-let g:tokyonight_style = 'night' " available: night, storm
-let g:tokyonight_enable_italic = 1
-let g:tokyonight_transparent_background = 1
-colorscheme tokyonight
+colorscheme nord
 
 " Highlight current line.
 set cursorline
@@ -234,7 +231,7 @@ hi CursorLine cterm=underline gui=underline
 " Lightline Config
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:lightline = {
-      \ 'colorscheme': 'tokyonight',
+      \ 'colorscheme': 'nord',
       \ 'active': {
       \   'right': [
       \     ['lineinfo'], ['percent'],

--- a/.vimrc
+++ b/.vimrc
@@ -26,10 +26,8 @@ call plug#begin('~/.vim/plugged')
   " Git Helpers
   Plug 'airblade/vim-gitgutter'
 
-  " linting
+  " ALE, for Linting
   Plug 'dense-analysis/ale'
-  "     Include lint results in lightline
-  Plug 'maximbaz/lightline-ale'
 
   " file finder, buffer manager
   Plug 'ctrlpvim/ctrlp.vim'
@@ -229,7 +227,7 @@ augroup END
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Color
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-set t_Co=256 " 256 colors
+" set t_Co=256 " 256 colors
 set background=dark
 colorscheme night-owl
 let g:one_allow_italics=1
@@ -254,7 +252,6 @@ let g:lightline = {
       \ 'colorscheme': 'nightowl',
       \ 'active': {
       \   'right': [
-      \     ['linter_checking', 'linter_errors', 'linter_warnings', 'linter_infos', 'linter_ok'],
       \     ['lineinfo'], ['percent'],
       \     ['fileformat', 'fileencoding', 'filetype', 'sharpenup']
       \   ]
@@ -265,28 +262,7 @@ let g:lightline = {
       \ 'component': {
       \   'sharpenup': sharpenup#statusline#Build()
       \ },
-      \ 'component_expand': {
-      \   'linter_checking': 'lightline#ale#checking',
-      \   'linter_infos': 'lightline#ale#infos',
-      \   'linter_warnings': 'lightline#ale#warnings',
-      \   'linter_errors': 'lightline#ale#errors',
-      \   'linter_ok': 'lightline#ale#ok'
-      \  },
-      \ 'component_type': {
-      \   'linter_checking': 'right',
-      \   'linter_infos': 'right',
-      \   'linter_warnings': 'warning',
-      \   'linter_errors': 'error',
-      \   'linter_ok': 'right'
-      \  }
       \}
-let g:lightline.component_type = {
-      \     'linter_checking': 'right',
-      \     'linter_infos': 'right',
-      \     'linter_warnings': 'warning',
-      \     'linter_errors': 'error',
-      \     'linter_ok': 'right',
-      \ }
 
 let g:sharpenup_statusline_opts = { 'Text': '%s (%p/%P)' }
 let g:sharpenup_statusline_opts.Highlight = 0
@@ -298,69 +274,6 @@ augroup END
 
 let g:asyncomplete_auto_popup = 1
 let g:asyncomplete_auto_completeopt = 0
-
-" Use unicode chars for ale indicators in the statusline
-let g:lightline#ale#indicator_checking = "\uf110 "
-let g:lightline#ale#indicator_infos = "\uf129 "
-let g:lightline#ale#indicator_warnings = "\uf071 "
-let g:lightline#ale#indicator_errors = "\uf05e "
-let g:lightline#ale#indicator_ok = "\uf00c "
-
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" Ale Config
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-let g:ale_lint_on_text_changed = 'normal'
-let g:ale_lint_on_insert_leave = 1
-let g:ale_lint_delay = 0
-let g:ale_set_quickfix = 0
-let g:ale_set_loclist = 0
-let g:ale_fix_on_save = 1
-let g:ale_disable_lsp = 1
-
-highlight ALEWarning cterm=underline,bold,italic ctermfg=Yellow
-highlight ALEError cterm=underline,bold,italic ctermfg=Red
-
-""""
-" \ 'typescriptreact': ['eslint', 'tsserver'],
-" \ 'typescript.tsx': ['eslint', 'tsserver'],
-" \ 'javascript': ['xo'],
-"""
-let g:ale_linters = {
-      \'javascript': ['eslint'],
-      \ 'cs': ['OmniSharp'],
-      \ 'typescript': ['tsserver', 'eslint'],
-      \ 'php': ['php', 'phpcs'],
-      \ 'python': ['pylint'],
-      \ 'elixir': ['elixir-ls'],
-      \}
-" Disabled Fixers
-"
-"\'php': ['php_cs_fixer'],
-"\'cs': ['uncrustify'],
-      " \'typescript': ['prettier'],
-      " \'typescriptreact': ['prettier'],
-      " \'javascript': ['prettier'],
-let g:ale_fixers = {
-      \'python': ['black'],
-      \'typescript': ['prettier'],
-      \'elixir': ['mix_format'],
-      \'json': ['prettier'],
-      \'html': ['prettier'],
-      \}
-let g:ale_php_phpcs_standard = "PSR12"
-let g:ale_php_phpcs_options = "--exclude=Squiz.Functions.MultiLineFunctionDeclaration"
-" let g:ale_php_phpcs_options = "--exclude=Generic.Commenting.Todo,Generic.Files.LineLength,PSR2.ControlStructures.ControlStructureSpacing,CakePHP.Strings.ConcatenationSpacing,PSR1.Files.SideEffects"
-
-" let g:ale_python_black_options = "--skip-string-normalization"
-
-let g:ale_elixir_elixir_ls_release = "/Users/liam/LanguageServers/elixir-ls/"
-
-let g:ale_dart_dartanalyzer_executable = "dart analyze"
-let g:ale_dart_dartfmt_executable = "dart format"
-
-nmap <silent> <leader>a <Plug>(ale_next_wrap_error)
-nmap <silent> <leader>a <Plug>(ale_previous_wrap_error)
-nnoremap <leader>kA :ALEStopAllLSPs<cr>
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " MISC KEY MAPS
@@ -591,11 +504,6 @@ let g:php_cs_fixer_config_file = '.php_cs'
 " autocmd BufWritePost *.php silent! call PhpCsFixerFixFile()
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" Tagbar Config
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-nmap <leader>t :TagbarToggle<CR>
-
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Gutentags Config
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 fun FindCtagsIgnore()
@@ -659,7 +567,100 @@ let g:OmniSharp_highlight_groups = {
 " nnoremap <leader>tf :TsuQuickFix<cr>
 " let g:tsuquyomi_shortest_import_path = 1
 
+"""""""
+"" ALE
+"" Currently only used for C# files, CoC handles everything else
+"""""""
+let g:ale_linters = {
+      \ 'cs': ['OmniSharp'],
+      \ 'typescript': []
+      \}
+nmap <silent> \a  <Plug>(ale_next_wrap_error)
+nmap <silent> \A  <Plug>(ale_previous_wrap_error)
+
+highlight ALEWarning cterm=underline,bold,italic ctermfg=Yellow
+highlight ALEError cterm=underline,bold,italic ctermfg=Red
+highlight ALEInfo cterm=underline,bold,italic ctermfg=130
+
+highlight clear ALEErrorSign
+highlight clear ALEWarningSign
+highlight clear ALEInfoSign
+
+let g:ale_sign_error = '💥'
+let g:ale_sign_warning = '😬'
+let g:ale_sign_info = '❗️'
+
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "" Coc
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+set encoding=utf-8
+set updatetime=300
+set cmdheight=2
+set shortmess+=c
+
+" Always show the signcolumn, otherwise it would shift the text each time
+" diagnostics appear/become resolved.
+if has("patch-8.1.1564")
+  " Recently vim can merge signcolumn and number column into one
+  set signcolumn=number
+else
+  set signcolumn=yes
+endif
+
+inoremap <silent><expr> <TAB>
+      \ pumvisible() ? "\<C-n>" :
+      \ <SID>check_back_space() ? "\<TAB>" :
+      \ coc#refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+
+function! s:check_back_space() abort
+  let col = col('.') - 1
+  return !col || getline('.')[col - 1]  =~# '\s'
+endfunction
+
+inoremap <silent><expr> <c-@> coc#refresh()
+
+inoremap <silent><expr> <cr> pumvisible() ? coc#_select_confirm()
+                              \: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
+
+nmap <leader>ca  <Plug>(coc-codeaction)
 nmap <leader>qf  <Plug>(coc-fix-current)
+
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gr <Plug>(coc-references)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+
+nmap <leader>rn <Plug>(coc-rename)
+
+nnoremap <silent> K :call <SID>show_documentation()<CR>
+function! s:show_documentation()
+  if (index(['vim','help'], &filetype) >= 0)
+    execute 'h '.expand('<cword>')
+  elseif (coc#rpc#ready())
+    call CocActionAsync('doHover')
+  else
+    execute '!' . &keywordprg . " " . expand('<cword>')
+  endif
+endfunction
+
+xmap <leader>f  <Plug>(coc-format-selected)
+nmap <leader>f  <Plug>(coc-format-selected)
+
+nmap <silent> <leader>A <Plug>(coc-diagnostic-prev)
+nmap <silent> <leader>a <Plug>(coc-diagnostic-next)
+
+xmap <leader>f  <Plug>(coc-format-selected)
+nmap <leader>f  <Plug>(coc-format-selected)
+
+highlight CocWarningHighlight cterm=underline,bold,italic ctermfg=Yellow
+highlight CocErrorHighlight cterm=underline,bold,italic ctermfg=Red
+highlight CocInfoHighlight cterm=underline,bold,italic ctermfg=130
+
+command! -nargs=0 Prettier :CocCommand prettier.formatFile
+
+autocmd CursorHold * silent call CocActionAsync('highlight')
+nnoremap <silent><nowait> <space>a  :<C-u>CocList diagnostics<cr>
+command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
+
+let $NVIM_TUI_ENABLE_TRUE_COLOR=1


### PR DESCRIPTION
## CoC
It's been a while now and I can confidently say the experience with CoC has been exponentially better than Tsuquyomi for Typescript files. It also works beautifully with a host of other languages. Haven't quite used it for elixir dev yet, but I'm really eager to do so.
It unfortunately doesn't quite work with C# files for diagnostics, so I have to keep Ale around just for that. But it does integrate seamlessly with Omnisharp-Vim for autocomplete, which is nice.

## Nord
Night Owl was growing a little stale for me and also I got annoyed that it didn't seem to exactly match what I expected from example screenshots. I must have some misconfigured, but I can't figure out what it is. Even Nord has a few quirks it seems. e.g. from their site
<img width="998" alt="image" src="https://user-images.githubusercontent.com/8420028/117746053-b9505000-b1d9-11eb-8d50-26adce78c072.png">
vs in my editor
<img width="272" alt="image" src="https://user-images.githubusercontent.com/8420028/117746069-c3724e80-b1d9-11eb-8e50-725ffc407521.png">
Colors confound me. I fear it's due to some weirdo terminal nonsense I did to enable italics. Or maybe it's tmux. I'll probably. never know.
Tried Tokyo Night, but my goggle too much orange.

## FZF
CtrlP broke my heart. After many years of faithful service it seems to have broken in a way I can't abide. Searching not by path but file name consistently tripped an error where it was using more memory than vim would let it. [Judging by cursory googling it seems it's a runaway regex.](https://github.com/ctrlpvim/ctrlp.vim/issues/530).
ah well. I'm at last shoved into the world of Fzf as I've been told is way better anyway. We shall see!.

## Misc
- reconfigured `delta` for Nord
- updated tmux config based on [this blog post](https://juliu.is/a-simple-tmux/).
- added [hexokinase](https://github.com/RRethy/vim-hexokinase) for these cute little color preview chips in css files.